### PR TITLE
Replaced links to original aseprite in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,12 +31,12 @@ platforms:
 You can get the source code downloading a `Aseprite-v1.x-Source.zip`
 file from the latest Aseprite release:
 
-https://github.com/aseprite/aseprite/releases
+https://github.com/aseprite-gpl/aseprite/releases
 
 Or you can clone the repository and all its submodules using the
 following command:
 
-    git clone --recursive https://github.com/aseprite/aseprite.git
+    git clone --recursive https://github.com/aseprite-gpl/aseprite.git
 
 To update an existing clone you can use the following commands:
 
@@ -208,13 +208,13 @@ library that you want to be linked dynamically.
 If you use the official version of Allegro 4.4 library (i.e. you
 compile with `USE_SHARED_ALLEGRO4=ON`) you will experience a couple of
 known issues solved in
-[our patched version of Allegro 4.4 library](https://github.com/aseprite/aseprite/tree/master/src/allegro):
+[our patched version of Allegro 4.4 library](https://github.com/aseprite-gpl/aseprite/tree/master/src/allegro):
 
 * You will
   [not be able to resize the window](https://github.com/aseprite/aseprite/issues/192)
   ([patch](https://github.com/aseprite/aseprite/commit/920f6275d55113507121afcbcda80adb44cc0563)).
 * You will have problems
-  [adding HSV colors in non-English systems](https://github.com/aseprite/aseprite/commit/27b55030e26e93c5e8d9e7e21206c8709d46ff22)
+  [adding HSV colors in non-English systems](https://github.com/aseprite-gpl/aseprite/commit/27b55030e26e93c5e8d9e7e21206c8709d46ff22)
   using the warning icon.
 
 # Building Skia dependency


### PR DESCRIPTION
Replaced some links to the original aseprite repository which would let people clone and compile the non free source.